### PR TITLE
Add actix-web server and serve Swagger UI with generated specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # pollify
+
+### Requirements
+
+Install [Protocol Buffer Compiler](https://grpc.io/docs/protoc-installation/)

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "backend"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2021"
 name = "grpc"
 path = "src/grpc.rs"
 
+[[bin]]
+name = "web"
+path = "src/web.rs"
+
 [dependencies]
 tonic = { workspace = true }
 prost = { workspace = true }
@@ -17,4 +21,4 @@ common = { path = "../common" }
 tonic-web = "0.5.0"
 tower-http = "0.3.5"
 http = "0.2.8"
-
+actix-web = "4"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,3 +22,5 @@ tonic-web = "0.5.0"
 tower-http = "0.3.5"
 http = "0.2.8"
 actix-web = "4"
+utoipa = { version = "2", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "2", features = ["actix-web"] }

--- a/backend/src/web.rs
+++ b/backend/src/web.rs
@@ -1,0 +1,28 @@
+use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
+
+#[get("/")]
+async fn hello() -> impl Responder {
+    HttpResponse::Ok().body("Hello world!")
+}
+
+#[post("/echo")]
+async fn echo(req_body: String) -> impl Responder {
+    HttpResponse::Ok().body(req_body)
+}
+
+async fn manual_hello() -> impl Responder {
+    HttpResponse::Ok().body("Hey there!")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .service(hello)
+            .service(echo)
+            .route("/hey", web::get().to(manual_hello))
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}

--- a/backend/src/web.rs
+++ b/backend/src/web.rs
@@ -1,23 +1,56 @@
 use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
+use utoipa::{OpenApi, ToSchema};
+use utoipa_swagger_ui::SwaggerUi;
 
+#[derive(ToSchema)]
+struct ExampleSchema {}
+
+/// Get a Hello World page
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Succesfull greetings")
+    )
+)]
 #[get("/")]
 async fn hello() -> impl Responder {
     HttpResponse::Ok().body("Hello world!")
 }
 
+/// Get an echo of the request body
+#[utoipa::path(
+    responses(
+        (status = 200, description = "Succesfull echo")
+    )
+)]
 #[post("/echo")]
 async fn echo(req_body: String) -> impl Responder {
     HttpResponse::Ok().body(req_body)
 }
 
+/// Get a "hey" page
+#[utoipa::path(
+    get,
+    path = "/hey",
+    responses(
+        (status = 200, description = "Succesfull greetings in another way")
+    )
+)]
 async fn manual_hello() -> impl Responder {
     HttpResponse::Ok().body("Hey there!")
 }
+
+#[derive(OpenApi)]
+#[openapi(paths(hello, echo, manual_hello), components(schemas(ExampleSchema,)))]
+struct ApiDoc;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         App::new()
+            .service(
+                SwaggerUi::new("/swagger-ui/{_:.*}")
+                    .url("/api-doc/openapi.json", ApiDoc::openapi()),
+            )
             .service(hello)
             .service(echo)
             .route("/hey", web::get().to(manual_hello))

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "common"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "frontend"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR adds an actix-web server with example endpoints and generates OpenAPI spec for the endpoints. Also adds a Swagger UI to view generated specs.